### PR TITLE
Windows RLS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,8 @@ fn main() {
     let os = if cfg!(target_os = "macos"){"Macos"}
              else if cfg!(target_os = "windows"){"Windows"}
              else {"Linux"};
-    run(Command::new("make")
+    let make_cmd = if os == "Windows" { "mingw32-make" } else { "make" };
+    run(Command::new(make_cmd)
                 .arg(kind)
                 .arg(format!("OUTPUT={}", output.display()))
                 .arg(format!("OSNAME={}", os))

--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -24,7 +24,7 @@ ifeq ($(OSNAME),Windows)
 	$(FC) $(LINPACK) $(FFLAGS) $(OUTPUT)/linpack.o
 	$(FC) $(BLAS) $(FFLAGS) $(OUTPUT)/blas.o
 	$(FC) $(TIMER) $(FFLAGS) $(OUTPUT)/timer.o
-    $(FC) $(STRING) $(FFLAGS) $(OUTPUT)/string.o
+	$(FC) $(STRING) $(FFLAGS) $(OUTPUT)/string.o
 	@echo "creating static library"
 	$(FC) $(SFlAG) $(OUTPUT)/liblbfgs.dll $(OUTPUT)/*.o
 endif


### PR DESCRIPTION
I still don't know how to successfully link a project on Windows to `rusttimization` and `lbfgsb-sys`, but RLS on Windows does work with those changes. One simply needs to export/set FC. There's nothing to modify in `rusttimization` if we merge this.